### PR TITLE
Allow running the code_web exe from source

### DIFF
--- a/exe/code_web
+++ b/exe/code_web
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+load_path = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(load_path) unless $LOAD_PATH.include?(load_path)
+
 require 'code_web'
 require 'code_web/cli'
 


### PR DESCRIPTION
This allows you to have local code changes, and instead of using the installed gem (or not having the gem installed at all), it will use the local code instead.